### PR TITLE
SlideBar 컴포넌트 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,21 @@
-import './App.css';
-import TextButton from './components/atoms/TextButton';
+import { useState } from 'react';
+import SlideBar from './components/moecules/SlideBar';
 
 function App() {
+  const [isClickArr, setIsClickArr] = useState([false, true, false, false]);
   return (
     <div className="mx-2 my-2">
-      <TextButton color="white" shape="square">
-        중
-      </TextButton>
-      <TextButton color="white" shape="long">
-        개념 영상
-      </TextButton>
-      <TextButton color="gray">상세</TextButton>
+      <SlideBar
+        num={3}
+        firstText="학생 관리"
+        secondText="반 관리"
+        thirdText="강사 관리"
+        isClickArr={isClickArr}
+        setIsClickArr={setIsClickArr}
+      />
+      {isClickArr[1] && <div>1번</div>}
+      {isClickArr[2] && <div>2번</div>}
+      {isClickArr[3] && <div>3번</div>}
     </div>
   );
 }

--- a/src/components/atoms/TextButton.jsx
+++ b/src/components/atoms/TextButton.jsx
@@ -1,18 +1,18 @@
-import { useState } from 'react';
 import PropTypes from 'prop-types';
 
-function TextButton({ color, shape, children }) {
-  const [isClick, setIsClick] = useState(false);
-
-  const handleClick = () => {
-    setIsClick((prev) => !prev);
-  };
-
+function TextButton({
+  color,
+  shape,
+  children,
+  isClick,
+  handleClick,
+  moreStyle,
+}) {
   if (color === 'white')
     if (shape === 'long')
       return (
         <button
-          className={`py-1 px-20 border-hpBlack border-[0.072rem] rounded-lg text-2xl font-semibold ${isClick ? 'bg-hpWhiteBlue' : 'bg-white'}`}
+          className={`py-1 px-20 border-hpBlack border-[0.072rem] rounded-lg text-2xl font-semibold ${isClick ? 'bg-hpWhiteBlue' : 'bg-white'} ${moreStyle}`}
           type="button"
           onClick={handleClick}
         >
@@ -22,7 +22,7 @@ function TextButton({ color, shape, children }) {
     else if (shape === 'square')
       return (
         <button
-          className={`py-1 px-2 border-[0.072rem] rounded-lg text-2xl font-semibold ${isClick ? 'bg-hpWhiteBlue border-hpClickedWhiteBlue' : 'bg-white border-hpGray'}`}
+          className={`py-1 px-2 border-[0.072rem] rounded-lg text-2xl font-semibold ${isClick ? 'bg-hpWhiteBlue border-hpClickedWhiteBlue' : 'bg-white border-hpGray'} ${moreStyle}`}
           type="button"
           onClick={handleClick}
         >
@@ -32,7 +32,7 @@ function TextButton({ color, shape, children }) {
   if (color === 'gray')
     return (
       <button
-        className="py-1 px-10 border-hpGray border-[0.072rem] rounded-full text-2xl font-semibold bg-hpLightGray hover:bg-hpHoverLightGray"
+        className={`py-1 px-10 border-hpGray border-[0.072rem] rounded-full text-2xl font-semibold bg-hpLightGray hover:bg-hpHoverLightGray ${moreStyle}`}
         type="button"
       >
         {children}
@@ -44,11 +44,15 @@ TextButton.propTypes = {
   children: PropTypes.string.isRequired,
   color: PropTypes.oneOf(['white', 'gray']),
   shape: PropTypes.oneOf(['long', 'square']),
+  isClick: PropTypes.bool.isRequired,
+  handleClick: PropTypes.func.isRequired,
+  moreStyle: PropTypes.string,
 };
 
 TextButton.defaultProps = {
   color: 'white',
   shape: 'long',
+  moreStyle: '',
 };
 
 export default TextButton;

--- a/src/components/moecules/SlideBar.jsx
+++ b/src/components/moecules/SlideBar.jsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import TextButton from '../atoms/TextButton';
+
+function SlideBar({
+  num,
+  firstText,
+  secondText,
+  thirdText,
+  isClickArr,
+  setIsClickArr,
+}) {
+  const [leftPosition, setLeftPosition] = useState('left-2');
+
+  if (num === 2) {
+    return (
+      <div>
+        <div>
+          <TextButton
+            color="white"
+            shape="long"
+            isClick={isClickArr[1]}
+            handleClick={() => {
+              setIsClickArr([false, true, false, false]);
+              setLeftPosition('left-2');
+            }}
+            moreStyle="mr-4"
+          >
+            {firstText}
+          </TextButton>
+
+          <TextButton
+            color="white"
+            shape="long"
+            isClick={isClickArr[2]}
+            handleClick={() => {
+              setIsClickArr([false, false, true, false]);
+              setLeftPosition('left-[17.5rem]');
+            }}
+          >
+            {secondText}
+          </TextButton>
+        </div>
+        <div
+          className={`transition-[left] relative h-1 w-60 mt-1 bg-hpBlue ${leftPosition}`}
+        />
+      </div>
+    );
+  }
+  if (num === 3) {
+    return (
+      <div>
+        <div>
+          <TextButton
+            color="white"
+            shape="long"
+            isClick={isClickArr[1]}
+            handleClick={() => {
+              setIsClickArr([false, true, false, false]);
+              setLeftPosition('left-2');
+            }}
+            moreStyle="mr-4"
+          >
+            {firstText}
+          </TextButton>
+
+          <TextButton
+            color="white"
+            shape="long"
+            isClick={isClickArr[2]}
+            handleClick={() => {
+              setIsClickArr([false, false, true, false]);
+              setLeftPosition('left-[16.8rem]');
+            }}
+            moreStyle="mr-4"
+          >
+            {secondText}
+          </TextButton>
+
+          <TextButton
+            color="white"
+            shape="long"
+            isClick={isClickArr[3]}
+            handleClick={() => {
+              setIsClickArr([false, false, false, true]);
+              setLeftPosition('left-[33rem]');
+            }}
+          >
+            {thirdText}
+          </TextButton>
+        </div>
+        <div
+          className={`transition-[left] relative h-1 w-60 mt-1 bg-hpBlue ${leftPosition}`}
+        />
+      </div>
+    );
+  }
+}
+
+SlideBar.propTypes = {
+  num: PropTypes.number.isRequired,
+  firstText: PropTypes.string.isRequired,
+  secondText: PropTypes.string.isRequired,
+  thirdText: PropTypes.string,
+  isClickArr: PropTypes.arrayOf(PropTypes.bool.isRequired).isRequired,
+  setIsClickArr: PropTypes.func.isRequired,
+};
+
+SlideBar.defaultProps = {
+  thirdText: '',
+};
+export default SlideBar;


### PR DESCRIPTION
## 개요
- SlideBar 컴포넌트를 구현했습니다
- TextButton 컴포넌트도 수정

## 작업 내용
1. SlideBar 컴포넌트
Props 설명
- num: SlideBar내부에 몇개의 텍스트 버튼이 존재하는지 (2or 3값을 가짐)
- firstText: 첫 번째 버튼 내부에 들어갈 텍스트
- secondText: 두 번째 버튼 내부에 들어갈 텍스트
- thirdText: 세 번째 버튼 내부에 들어갈 텍스트
- isClickArr: 각 버튼의 클릭된 상태를 나타내는 배열 index 0번은 없는 셈 친다([true, false, false, false]) 
- setIsClickArr: isClickArr상태 값 업데이트 함수
2. TextButton 컴포넌트 Props 수정
- isClick: 각 버튼의 클릭 된 상태
- handleClick: onClick 함수
- moreStyle: 추가적인 tailwind style를 받을 수 있다.

## 스크린샷
![bandicam 2024-02-10 00-12-27-610](https://github.com/coririri/haanppen-math-frontend/assets/87762581/1e054943-1d62-4208-acec-a0919a2684b4)

resolve: #[3]
