### PR TITLE
feat: DayClassList 컴포넌트 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,16 @@
+import DayClassList from './components/moecules/DayClassList';
 import ClassList from './components/atoms/ClassList';
 
 function App() {
   return (
     <div className="m-4">
-      <ClassList
-        type="progress"
-        text="개념원리 중3-1 ~p.187 (이차함수의 그래프)"
-      />
-      <ClassList type="homework" text="~p.187 까지" />
+      <DayClassList date={new Date()} videoLink="mybox.com">
+        <ClassList
+          type="progress"
+          text="개념원리 중3-1 ~p.187 (이차함수의 그래프)"
+        />
+        <ClassList type="homework" text="~p.187 까지" />
+      </DayClassList>
     </div>
   );
 }

--- a/src/components/atoms/IconButton.jsx
+++ b/src/components/atoms/IconButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 function IconButton({ bgColor, icon, text, handleClick }) {
   if (bgColor === 'white') {
     return (
-      <button type="button" onClick={handleClick}>
+      <button type="button" onClick={handleClick} className="h-9">
         <div className="inline-flex items-center font-bold border-[0.075rem] border-solid py-2 pl-4 pr-6 rounded-lg">
           {icon}
           <span className="ml-4 text-xs">{text}</span>
@@ -13,7 +13,7 @@ function IconButton({ bgColor, icon, text, handleClick }) {
   }
   if (bgColor === 'red') {
     return (
-      <button type="button" onClick={handleClick}>
+      <button type="button" onClick={handleClick} className="h-9">
         <div className="bg-hpLightRed inline-flex items-center font-bold border-[0.075rem] border-solid border-[#A50028] py-[0.2rem] px-3 rounded-lg">
           <div className="w-7">{icon}</div>
           <span className="ml-2 text-xl text-white font-sjBold">{text}</span>
@@ -23,7 +23,7 @@ function IconButton({ bgColor, icon, text, handleClick }) {
   }
   if (bgColor === 'blue') {
     return (
-      <button type="button" onClick={handleClick}>
+      <button type="button" onClick={handleClick} className="h-9">
         <div className="bg-hpLightBlue inline-flex items-center font-bold border-[0.075rem] border-solid border-[#008FE0] py-[0.2rem] px-3 rounded-lg">
           <div className="w-7">{icon}</div>
           <span className="ml-2 text-xl text-white font-sjBold">{text}</span>

--- a/src/components/moecules/DayClassList.jsx
+++ b/src/components/moecules/DayClassList.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { MdOndemandVideo } from 'react-icons/md';
+import IconButton from '../atoms/IconButton';
+import getDayInKorean from '../../utils/getDayInKorean';
+
+function DayClassList({ date, videoLink, children }) {
+  return (
+    <div className="w-[30rem] h-[8rem] border-[0.075rem] border-solid rounded-lg pb-2">
+      <div className="flex h-12 items-center w-[18.5rem] mx-auto">
+        <div className="bg-hpLightRed text-white font-sjBold px-4 py-1 h-9 rounded-lg text-xl mr-2">
+          {date.getMonth() + 1}.{date.getDate()}({getDayInKorean(date.getDay())}
+          ) 수업
+        </div>
+        <IconButton
+          bgColor="blue"
+          text="영상 확인"
+          handleClick={() => {
+            console.log(videoLink);
+          }}
+          icon={<MdOndemandVideo color="white" size="1.7rem" />}
+        />
+      </div>
+      <div className="w-[28rem] mx-auto mt-2 mb-2">{children}</div>
+    </div>
+  );
+}
+
+DayClassList.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  videoLink: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default DayClassList;

--- a/src/utils/getDayInKorean.js
+++ b/src/utils/getDayInKorean.js
@@ -1,0 +1,10 @@
+export default function getDayInKorean(date) {
+  if (date === 0) return '일';
+  if (date === 1) return '월';
+  if (date === 2) return '화';
+  if (date === 3) return '수';
+  if (date === 4) return '목';
+  if (date === 5) return '금';
+  if (date === 6) return '토';
+  return '요일 없음';
+}


### PR DESCRIPTION
## 개요
- DayClassList 컴포넌트 구현

## 작업 내용
- Props 
1. date
- Date 객체를 내려줌
2. videoLink
- 영상 링크를 줌 (아직 완벽 구현 X)
3. children
- 숙제, 진도 리스트가 들어감

- getDayInKorean Util함수 구현
0-6의 인덱스를 => 일-토로 변환해주는 함수

## 스크린샷
![bandicam 2024-02-16 01-27-36-932](https://github.com/coririri/haanppen-math-frontend/assets/87762581/ba7a556d-126f-4062-9539-9c4478f0d4f3)