### PR TITLE
feat: ClassDropdown Component 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,151 @@
-import TeacherManagementContainer from './components/organisms/TeacherManagementContainer';
+import { useState } from 'react';
+import ClassDropdown from './components/organisms/ClassDropdown';
 
 function App() {
+  const [classInformation, setGradeByStudent] = useState([
+    {
+      grade: 1,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 2,
+      num: 1,
+      students: ['김땡땡'],
+    },
+    {
+      grade: 3,
+      num: 3,
+      students: ['이땡땡', '선땡땡', '주땡땡'],
+    },
+    {
+      grade: 4,
+      num: 5,
+      students: ['후땡땡', '알땡땡', '쿠땡땡', '냥땡땡', '뿌뿌뿌'],
+    },
+    {
+      grade: 5,
+      num: 5,
+      students: ['후땡땡', '알땡땡', '쿠땡땡', '냥땡땡', '뿌뿌뿌'],
+    },
+    {
+      grade: 6,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 7,
+      num: 2,
+      students: ['냥땡땡', '뿌뿌뿌'],
+    },
+    {
+      grade: 8,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 9,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 10,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 11,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 12,
+      num: 0,
+      students: [],
+    },
+  ]);
+
+  const [newClassInformation, setNewGradeByStudent] = useState([
+    {
+      grade: 1,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 2,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 3,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 4,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 5,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 6,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 7,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 8,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 9,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 10,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 11,
+      num: 0,
+      students: [],
+    },
+    {
+      grade: 12,
+      num: 0,
+      students: [],
+    },
+  ]);
+
   return (
-    <div>
-      <TeacherManagementContainer />
+    <div className="m-4 flex ">
+      <ClassDropdown
+        gradeByStudent={classInformation}
+        setGradeByStudent={setGradeByStudent}
+        newClassInformation={newClassInformation}
+        setNewGradeByStudent={setNewGradeByStudent}
+        type="plus"
+      />
+      <div className="ml-4">
+        <ClassDropdown
+          gradeByStudent={classInformation}
+          setGradeByStudent={setGradeByStudent}
+          newClassInformation={newClassInformation}
+          setNewGradeByStudent={setNewGradeByStudent}
+          type="minus"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/atoms/TextButton.jsx
+++ b/src/components/atoms/TextButton.jsx
@@ -1,6 +1,14 @@
 import PropTypes from 'prop-types';
 
-function TextButton({ color, shape, text, isClick, handleClick, moreStyle }) {
+function TextButton({
+  color,
+  shape,
+  size,
+  text,
+  isClick,
+  handleClick,
+  moreStyle,
+}) {
   if (color === 'white')
     if (shape === 'long')
       return (
@@ -27,17 +35,54 @@ function TextButton({ color, shape, text, isClick, handleClick, moreStyle }) {
       <button
         className={`inline-block w-[6.25rem] h-[2rem] border-hpGray border-[0.072rem] rounded-full font-bold bg-hpLightGray hover:bg-hpHoverLightGray ${moreStyle}`}
         type="button"
+        onClick={handleClick}
       >
         <span className="text-xl">{text}</span>
       </button>
     );
+  if (shape === 'math') {
+    if (size === 'big') {
+      return (
+        <button
+          className={`inline-block w-[2.125rem] h-[2.125rem] border-hpWhiteBlue border-[0.072rem] rounded-full font-bold bg-hpWhiteBlue hover:border-hpClickedWhiteBlue ${moreStyle}`}
+          type="button"
+          onClick={handleClick}
+        >
+          <span className="text-3xl leading-[2.125rem]">{text}</span>
+        </button>
+      );
+    }
+    if (size === 'small') {
+      return (
+        <button
+          className={`inline-block w-[1.43rem] h-[1.43rem] border-hpWhiteBlue border-[0.072rem] rounded-full font-bold bg-hpWhiteBlue hover:border-hpClickedWhiteBlue ${moreStyle}`}
+          type="button"
+          onClick={handleClick}
+        >
+          <span className="text-xl leading-[1.43rem]">{text}</span>
+        </button>
+      );
+    }
+    if (size === 'tooSmall') {
+      return (
+        <button
+          className={`inline-block w-[1.2rem] h-[1.2rem] leading-[1.2rem] bg-hpBlack text-white hover:border-hpBlack border-hpLightBlack border-[0.072rem] rounded-full font-bold ${moreStyle}`}
+          type="button"
+          onClick={handleClick}
+        >
+          <span className="text-xl leading-[1.2rem]">{text}</span>
+        </button>
+      );
+    }
+  }
 }
 
 TextButton.propTypes = {
   text: PropTypes.string.isRequired,
   color: PropTypes.oneOf(['white', 'gray']),
-  shape: PropTypes.oneOf(['long', 'square']),
-  isClick: PropTypes.bool.isRequired,
+  shape: PropTypes.oneOf(['long', 'square', 'math']),
+  size: PropTypes.oneOf(['big', 'small', 'tooSmall']),
+  isClick: PropTypes.bool,
   handleClick: PropTypes.func.isRequired,
   moreStyle: PropTypes.string,
 };
@@ -46,6 +91,8 @@ TextButton.defaultProps = {
   color: 'white',
   shape: 'long',
   moreStyle: '',
+  size: 'small',
+  isClick: false,
 };
 
 export default TextButton;

--- a/src/components/molecules/ClassDropdownList.jsx
+++ b/src/components/molecules/ClassDropdownList.jsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { BsFillTriangleFill } from 'react-icons/bs';
+import TextButton from '../atoms/TextButton';
+import gradeTransform from '../../utils/gradeTransform';
+import studentByGrade from '../../types/studentByGrade';
+
+function ClassDropdownList({
+  grade,
+  num,
+  students,
+  gradeByStudent,
+  setGradeByStudent,
+  newClassInformation,
+  setNewGradeByStudent,
+  type,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClickPlusButton = (plusType, student) => {
+    if (plusType === 'grade') {
+      const updatedArray = [...gradeByStudent];
+      updatedArray.splice(grade - 1, 1, {
+        grade,
+        num: 0,
+        students: [],
+      });
+
+      const updatedNewArray = [...newClassInformation];
+      updatedNewArray.splice(grade - 1, 1, {
+        grade,
+        num: updatedNewArray[grade - 1].num + num,
+        students: [...updatedNewArray[grade - 1].students, ...students],
+      });
+
+      setNewGradeByStudent(updatedNewArray);
+      setGradeByStudent(updatedArray);
+    } else if (plusType === 'student') {
+      const updatedArray = [...gradeByStudent];
+      updatedArray.splice(grade - 1, 1, {
+        grade,
+        num: num - 1,
+        students: students.filter((err) => err !== student),
+      });
+
+      const updatedNewArray = [...newClassInformation];
+      updatedNewArray.splice(grade - 1, 1, {
+        grade,
+        num: updatedNewArray[grade - 1].num + 1,
+        students: [...updatedNewArray[grade - 1].students, student],
+      });
+
+      setNewGradeByStudent(updatedNewArray);
+      setGradeByStudent(updatedArray);
+    }
+  };
+
+  const handleClickMinusButton = (plusType, student) => {
+    if (plusType === 'grade') {
+      const updatedArray = [...newClassInformation];
+      updatedArray.splice(grade - 1, 1, {
+        grade,
+        num: 0,
+        students: [],
+      });
+
+      const updatedNewArray = [...gradeByStudent];
+      updatedNewArray.splice(grade - 1, 1, {
+        grade,
+        num: updatedNewArray[grade - 1].num + num,
+        students: [...updatedNewArray[grade - 1].students, ...students],
+      });
+
+      setNewGradeByStudent(updatedArray);
+      setGradeByStudent(updatedNewArray);
+    } else if (plusType === 'student') {
+      const updatedArray = [...newClassInformation];
+      updatedArray.splice(grade - 1, 1, {
+        grade,
+        num: num - 1,
+        students: students.filter((err) => err !== student),
+      });
+
+      const updatedNewArray = [...gradeByStudent];
+      updatedNewArray.splice(grade - 1, 1, {
+        grade,
+        num: updatedNewArray[grade - 1].num + 1,
+        students: [...updatedNewArray[grade - 1].students, student],
+      });
+
+      setNewGradeByStudent(updatedArray);
+      setGradeByStudent(updatedNewArray);
+    }
+  };
+
+  return (
+    <div className="w-[19.68rem]">
+      <button
+        type="button"
+        className="w-[19.68rem] h-[2.625rem] flex items-center border-solid border-b-[0.05rem] border-hpGray bg-hpLightGray"
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+      >
+        <div className="w-[3.68rem]">
+          <div
+            className={`transition-transform w-[1.375rem] h-[1.375rem] mx-auto ${isOpen ? 'rotate-180 pr-8' : 'rotate-90 pb-8'}`}
+          >
+            <BsFillTriangleFill size="1.375rem" color="#BCBCBC" />
+          </div>
+        </div>
+        <span className="w-[2.5rem] leading-[2.625rem] text-lg font-bold text-center">
+          {gradeTransform(grade)}
+        </span>
+        <span className="w-[3.5rem] pr-2 leading-[2.625rem] text-lg text-hpLightkBlack font-bold text-center">
+          {num}명
+        </span>
+        {type === 'plus' ? (
+          <div className="w-[10rem] text-right pr-8">
+            <TextButton
+              color="white"
+              shape="math"
+              size="small"
+              text="+"
+              handleClick={(e) => {
+                e.stopPropagation();
+                handleClickPlusButton('grade');
+              }}
+            />
+          </div>
+        ) : (
+          <div className="w-[10rem] text-right pr-8">
+            <TextButton
+              color="white"
+              shape="math"
+              size="small"
+              text="-"
+              handleClick={(e) => {
+                e.stopPropagation();
+                handleClickMinusButton('grade');
+              }}
+            />
+          </div>
+        )}
+      </button>
+      {isOpen
+        ? students.map((student) => (
+            <div
+              className="w-[19.68rem] h-[2.625rem] flex items-center border-solid border-b-[0.05rem] border-hpGray"
+              key={student}
+            >
+              <span className="w-[8rem] pl-14 font-bold text-sm">
+                {student}
+              </span>
+              {type === 'plus' ? (
+                <div className="w-[11.68rem] text-right pr-[2.1rem]">
+                  <TextButton
+                    color="white"
+                    shape="math"
+                    size="tooSmall"
+                    text="+"
+                    handleClick={() => {
+                      handleClickPlusButton('student', student);
+                    }}
+                    moreStyle="bg-hpBlack text-white hover:border-hpBlack border-hpLightBlack"
+                  />
+                </div>
+              ) : (
+                <div className="w-[11.68rem] text-right pr-[2.1rem]">
+                  <TextButton
+                    color="white"
+                    shape="math"
+                    size="tooSmall"
+                    text="-"
+                    handleClick={() => {
+                      handleClickMinusButton('student', student);
+                    }}
+                    moreStyle="bg-hpBlack text-white hover:border-hpBlack border-hpLightBlack"
+                  />
+                </div>
+              )}
+            </div>
+          ))
+        : null}
+    </div>
+  );
+}
+
+ClassDropdownList.propTypes = {
+  grade: PropTypes.number.isRequired,
+  num: PropTypes.number.isRequired,
+  students: PropTypes.arrayOf(PropTypes.string).isRequired,
+  gradeByStudent: PropTypes.arrayOf(PropTypes.shape(studentByGrade)).isRequired,
+  setGradeByStudent: PropTypes.func.isRequired,
+  newClassInformation: PropTypes.arrayOf(PropTypes.shape(studentByGrade))
+    .isRequired,
+  setNewGradeByStudent: PropTypes.func.isRequired,
+  type: PropTypes.oneOf(['plus', 'minus']).isRequired,
+};
+
+export default ClassDropdownList;

--- a/src/components/organisms/ClassDropdown.jsx
+++ b/src/components/organisms/ClassDropdown.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import ClassDropdownList from '../molecules/ClassDropdownList';
+import studentByGrade from '../../types/studentByGrade';
+
+function ClassDropdown({
+  gradeByStudent,
+  setGradeByStudent,
+  newClassInformation,
+  setNewGradeByStudent,
+  type,
+}) {
+  return (
+    <div className="w-[19.81rem] h-[32.93rem] scroll overflow-y-auto overflow-x-hidden border-[0.1rem] border-hpLightkBlack border-solid rounded-lg">
+      {type === 'plus'
+        ? gradeByStudent
+            .filter((err) => err.num > 0)
+            .map((err) => (
+              <ClassDropdownList
+                key={err.grade}
+                grade={err.grade}
+                num={err.num}
+                students={err.students}
+                gradeByStudent={gradeByStudent}
+                setGradeByStudent={setGradeByStudent}
+                newClassInformation={newClassInformation}
+                setNewGradeByStudent={setNewGradeByStudent}
+                type={type}
+              />
+            ))
+        : newClassInformation
+            .filter((err) => err.num > 0)
+            .map((err) => (
+              <ClassDropdownList
+                key={err.grade}
+                grade={err.grade}
+                num={err.num}
+                students={err.students}
+                gradeByStudent={gradeByStudent}
+                setGradeByStudent={setGradeByStudent}
+                newClassInformation={newClassInformation}
+                setNewGradeByStudent={setNewGradeByStudent}
+                type={type}
+              />
+            ))}
+    </div>
+  );
+}
+
+ClassDropdown.propTypes = {
+  gradeByStudent: PropTypes.arrayOf(PropTypes.shape(studentByGrade)).isRequired,
+  setGradeByStudent: PropTypes.func.isRequired,
+  newClassInformation: PropTypes.arrayOf(PropTypes.shape(studentByGrade))
+    .isRequired,
+  setNewGradeByStudent: PropTypes.func.isRequired,
+  type: PropTypes.oneOf(['plus', 'minus']).isRequired,
+};
+
+export default ClassDropdown;

--- a/src/types/studentByGrade.js
+++ b/src/types/studentByGrade.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types';
+
+const studentByGrade = {
+  grade: PropTypes.number.isRequired,
+  num: PropTypes.number.isRequired,
+  students: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default studentByGrade;


### PR DESCRIPTION
## 개요
- ClassDropdown 컴포넌트 구현
- ClassDropdownList 컴포넌트 구현

## 작업 내용
1, ClassDropdownList 컴포넌트
- handleClickPlusButton 함수 구현: plusType, student를 인자로 받으며 plus버튼을 눌렀을 때 
classInformation, newClassInformation 상태 값을 업데이트 하여 UI와 상태 값을 수정한다
- handleClickMinusButton 함수 구현: plusType, student를 인자로 받으며 minus버튼을 눌렀을 때 
classInformation, newClassInformation 상태 값을 업데이트 하여 UI와 상태 값을 수정한다
- UI 구현
- Prop
1. grade: List의 학년을 받는다
2. num: 해당 학년이 몇 명인지 받는다
3. students: 해당 학년의 학생 이름들을 string 배열로 받는다
4. gradeByStudent, setGradeByStudent: 전체 학생들의 상태 값
5. newClassInformation, setNewGradeByStudent: 선택 된 학생들의 상태 값
6. type: plus인지 minus인지를 통해 전체 학생의 List인지 선택 된 학생의 List인지를 결정

2. ClassDropdown 컴포넌트 구현
- UI 구현
- map함수를 통해 ClassDropdownList을 렌더링한다
- Prop
1. gradeByStudent, setGradeByStudent: 전체 학생들의 상태 값
2. newClassInformation, setNewGradeByStudent: 선택 된 학생들의 상태 값
3. type: plus인지 minus인지를 통해 전체 학생의 List인지 선택 된 학생의 List인지를 결정

3. TextButton 컴포넌트 수정
- shape Prop에 'math'를 추가해 +, - 같은 기호 버튼을 추가하였다 size도 'big', 'small'을 추가 해 mathButton일때 사이즈를 추가 조절할 수 있다

## 스크린샷
![bandicam 2024-02-29 19-00-30-273](https://github.com/coririri/haanppen-math-frontend/assets/87762581/233bca1c-70bd-44b4-891e-6849dfc52943)

resolve: #27
