### PR TITLE
Config/dropdown menu UI&기능 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,64 @@
-import { useRef } from 'react';
-import Input from './components/atoms/Input';
+import { useState } from 'react';
+import DropdownMenu from './components/molecules/DropdownMenu';
 
 function App() {
-  const inputRef = useRef(null);
+  const textArr = [
+    '입양하세요',
+    '브레이크 인',
+    '브룩헤이븐 RP',
+    '제일 브레이크',
+    '밉시티',
+    '머더 미스터리 2',
+    '자연 재해 생존',
+    '배드워즈',
+  ];
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isOpenIndexArr, setIsOpenIndexArr] = useState([
+    false,
+    false,
+    false,
+    false,
+  ]);
+
+  const handleClickDropdownMenu = (index) => {
+    let updatedOpenIndexArr = [...isOpenIndexArr];
+    if (updatedOpenIndexArr[index] === true) {
+      updatedOpenIndexArr[index] = false;
+    } else if (updatedOpenIndexArr[index] === false) {
+      updatedOpenIndexArr = Array(updatedOpenIndexArr.length).fill(false);
+      updatedOpenIndexArr[index] = true;
+    }
+    setIsOpenIndexArr(updatedOpenIndexArr);
+  };
 
   return (
-    <div className="m-2">
-      <Input
-        type="search"
-        inputRef={inputRef}
-        placeholder="반 이름 검색"
-        handleClickSearch={() => {
-          console.log(inputRef.current?.value);
-        }}
+    <div className="m-2 h-[20rem] flex-col flex justify-between">
+      <DropdownMenu
+        size="normal"
+        textArr={textArr}
+        selectedIndex={selectedIndex}
+        setSelectedIndex={setSelectedIndex}
+        isOpen={isOpenIndexArr[0]}
+        order={0}
+        handleClick={handleClickDropdownMenu}
+      />
+      <DropdownMenu
+        size="normal"
+        textArr={textArr}
+        selectedIndex={selectedIndex}
+        setSelectedIndex={setSelectedIndex}
+        isOpen={isOpenIndexArr[1]}
+        order={1}
+        handleClick={handleClickDropdownMenu}
+      />
+      <DropdownMenu
+        size="normal"
+        textArr={textArr}
+        selectedIndex={selectedIndex}
+        setSelectedIndex={setSelectedIndex}
+        isOpen={isOpenIndexArr[2]}
+        order={2}
+        handleClick={handleClickDropdownMenu}
       />
     </div>
   );

--- a/src/components/molecules/DropdownMenu.jsx
+++ b/src/components/molecules/DropdownMenu.jsx
@@ -2,21 +2,24 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { BsTriangleFill } from 'react-icons/bs';
 
-function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size }) {
-  const [isOpen, setIsOpen] = useState(false);
+function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, handleClick }) {
 
   let sizeByWidth = '';
   let sizeByTextSize = '';
+  let leftPaddingText = '';
 
   if (size === 'long') {
     sizeByWidth = 'w-[25.25rem]';
     sizeByTextSize = 'text-md';
+    leftPaddingText = 'pl-6';
   } else if (size === 'normal') {
     sizeByWidth = 'w-60';
     sizeByTextSize = 'text-xl';
+    leftPaddingText = 'pl-6';
   } else if (size === 'small') {
     sizeByWidth = 'w-32';
     sizeByTextSize = 'text-xl';
+    leftPaddingText = 'pl-4';
   }
 
   const dropdownList = textArr.map((text, index) => {
@@ -24,7 +27,7 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size }) {
       selectedIndex !== index ? (
         <button
           type="button"
-          className={`w-[24.75rem] h-[3rem] flex items-center font-bold ${sizeByTextSize} hover:bg-hpLightGray`}
+          className={`${sizeByWidth} h-[3rem] flex items-center font-bold ${sizeByTextSize} hover:bg-hpLightGray`}
           key={text}
           onClick={() => {
             setSelectedIndex(index);
@@ -32,7 +35,7 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size }) {
           }}
         >
           <div
-            className={`w-[23rem] h-[2.4rem] leading-[2.4rem] ${sizeByTextSize} text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto`}
+            className={`${sizeByWidth} h-[2.4rem] leading-[2.4rem] ${sizeByTextSize} text-left ${leftPaddingText} whitespace-nowrap overflow-hidden hover:overflow-x-auto`}
           >
             {text}
           </div>
@@ -45,38 +48,86 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size }) {
     (text, index) => index !== selectedIndex,
   );
 
-  return (
-    <div
-      className={`${sizeByWidth} h-[16rem] ${isOpen ? 'border-[0.075rem] rounded-lg border-hpLightkBlack border-solid' : ''}`}
-    >
-      <button
-        type="button"
-        className={`${sizeByWidth} h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-b-[0.075rem]' : 'border-[0.075rem] rounded-lg'}`}
-        key={textArr[selectedIndex]}
-        onClick={() => {
-          setIsOpen((prev) => !prev);
-        }}
-      >
-        <div
-          className={`w-[23rem] h-[2.4rem] leading-[2.4rem] ${sizeByTextSize} text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto`}
+  if (size === 'long')
+    return (
+      <div className="w-[25.25rem] h-[2.4rem] relative">
+        <button
+          type="button"
+          className={`w-[25.25rem] h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
+          key={textArr[selectedIndex]}
+          onClick={handleClick}
         >
-          {textArr[selectedIndex]}
-        </div>
-        <div
-          className={`w-[1.875rem] transition-[transform] origin-center ${isOpen ? 'rotate-180 mr-5' : 'rotate-0 mr-4'}`}
+          <div className="w-[23rem] h-[2.4rem] leading-[2.4rem] text-md text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
+            {textArr[selectedIndex]}
+          </div>
+          <div
+            className={`w-[2.25rem] transition-[transform] origin-center ${isOpen ? 'rotate-180 pl-3' : 'rotate-0'}`}
+          >
+            <BsTriangleFill color="#BCBCBC" size="1.5rem" />
+          </div>
+        </button>
+
+        {isOpen && (
+          <div className="absolute w-[25.25rem] h-[13.6rem] bg-white z-10 border-x-[0.075rem] border-b-[0.075rem] border-hpLightkBlack border-solid flex flex-col overflow-y-auto overflow-x-hidden">
+            {filteredList}
+          </div>
+        )}
+      </div>
+    );
+
+  if (size === 'normal')
+    return (
+      <div className="w-60 h-[2.4rem] relative">
+        <button
+          type="button"
+          className={`w-60 h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
+          key={textArr[selectedIndex]}
+          onClick={handleClick}
         >
-          <BsTriangleFill color="#BCBCBC" size="1.5rem" />
-        </div>
-      </button>
-      {isOpen && (
-        <div
-          className={`${sizeByWidth} h-[13.6rem] flex flex-col overflow-y-auto`}
+          <div className="w-56 h-[2.4rem] leading-[2.4rem] text-xl text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
+            {textArr[selectedIndex]}
+          </div>
+          <div
+            className={`w-4 transition-[transform] origin-center ${isOpen ? 'rotate-180 mr-2' : 'rotate-0 mr-4'}`}
+          >
+            <BsTriangleFill color="#BCBCBC" size="1.5rem" />
+          </div>
+        </button>
+
+        {isOpen && (
+          <div className="absolute w-60 h-[13.6rem] bg-white z-10 border-x-[0.075rem] border-b-[0.075rem] border-hpLightkBlack border-solid flex flex-col overflow-y-auto overflow-x-hidden">
+            {filteredList}
+          </div>
+        )}
+      </div>
+    );
+
+  if (size === 'small')
+    return (
+      <div className="w-32 h-[2.4rem] relative">
+        <button
+          type="button"
+          className={`w-32 h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
+          key={textArr[selectedIndex]}
+          onClick={handleClick}
         >
-          {filteredList}
-        </div>
-      )}
-    </div>
-  );
+          <div className="w-30 h-[2.4rem] leading-[2.4rem] text-xl text-left pl-4 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
+            {textArr[selectedIndex]}
+          </div>
+          <div
+            className={`w-2 transition-[transform] origin-center ${isOpen ? 'rotate-180 ml-6' : 'rotate-0 ml-4'}`}
+          >
+            <BsTriangleFill color="#BCBCBC" size="1rem" />
+          </div>
+        </button>
+
+        {isOpen && (
+          <div className="absolute w-32 h-[13.6rem] bg-white z-10 border-x-[0.075rem] border-b-[0.075rem] border-hpLightkBlack border-solid flex flex-col overflow-y-auto overflow-x-hidden">
+            {filteredList}
+          </div>
+        )}
+      </div>
+    );
 }
 
 DropdownMenu.propTypes = {
@@ -84,6 +135,8 @@ DropdownMenu.propTypes = {
   selectedIndex: PropTypes.number.isRequired,
   setSelectedIndex: PropTypes.func.isRequired,
   size: PropTypes.oneOf(['small', 'normal', 'long']).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  handleClick: PropTypes.func.isRequired
 };
 
 export default DropdownMenu;

--- a/src/components/molecules/DropdownMenu.jsx
+++ b/src/components/molecules/DropdownMenu.jsx
@@ -1,9 +1,15 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 import { BsTriangleFill } from 'react-icons/bs';
 
-function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, handleClick }) {
-
+function DropdownMenu({
+  size,
+  textArr,
+  selectedIndex,
+  setSelectedIndex,
+  isOpen,
+  order,
+  handleClick,
+}) {
   let sizeByWidth = '';
   let sizeByTextSize = '';
   let leftPaddingText = '';
@@ -31,7 +37,7 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, 
           key={text}
           onClick={() => {
             setSelectedIndex(index);
-            setIsOpen(false);
+            handleClick(order);
           }}
         >
           <div
@@ -55,7 +61,9 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, 
           type="button"
           className={`w-[25.25rem] h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
           key={textArr[selectedIndex]}
-          onClick={handleClick}
+          onClick={() => {
+            handleClick(order);
+          }}
         >
           <div className="w-[23rem] h-[2.4rem] leading-[2.4rem] text-md text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
             {textArr[selectedIndex]}
@@ -82,7 +90,9 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, 
           type="button"
           className={`w-60 h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
           key={textArr[selectedIndex]}
-          onClick={handleClick}
+          onClick={() => {
+            handleClick(order);
+          }}
         >
           <div className="w-56 h-[2.4rem] leading-[2.4rem] text-xl text-left pl-6 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
             {textArr[selectedIndex]}
@@ -109,7 +119,9 @@ function DropdownMenu({ textArr, selectedIndex, setSelectedIndex, size, isOpen, 
           type="button"
           className={`w-32 h-[2.4rem] font-bold  border-hpLightkBlack border-solid flex items-center ${isOpen ? 'border-[0.075rem] rounded-t-lg' : 'border-[0.075rem] rounded-lg'}`}
           key={textArr[selectedIndex]}
-          onClick={handleClick}
+          onClick={() => {
+            handleClick(order);
+          }}
         >
           <div className="w-30 h-[2.4rem] leading-[2.4rem] text-xl text-left pl-4 whitespace-nowrap overflow-hidden hover:overflow-x-auto">
             {textArr[selectedIndex]}
@@ -136,7 +148,8 @@ DropdownMenu.propTypes = {
   setSelectedIndex: PropTypes.func.isRequired,
   size: PropTypes.oneOf(['small', 'normal', 'long']).isRequired,
   isOpen: PropTypes.bool.isRequired,
-  handleClick: PropTypes.func.isRequired
+  order: PropTypes.number.isRequired,
+  handleClick: PropTypes.func.isRequired,
 };
 
 export default DropdownMenu;


### PR DESCRIPTION
## 개요
- UI수정
- 기능 추가

## 작업 내용
- UI 수정
1. z-index와 bg-white를 추가해 Dropdown컴포넌트의 UI가 외부와 겹치는 것을 해결
- 기능 추가 (Props 설명)
2. 코드 리팩토링
- 한 눈에 알아보기 쉽게 if문을 활용해 size 별로 따로 코드를 작성하였다
- 기능 추가 (Props 설명)
1. isOpen
해당 Dropdown 컴포넌트의 open State를 부모에게서 받아온다
2. order
해당 Dropdown 컴포넌트가 몇 번째 순서의 컴포넌트인지 부모에게서 받아온다
3. handleClick
해당 Dropdown 컴포넌트의 Dropdonw을 여는 버튼 또는 목록을 선택하는 버튼을 클릭시 다른 Dropdown 컴포넌트들을 닫고 현재 컴포넌트를 열거나, 열려있는 Dropdown컴포넌트를 닫는 setIsOpen 기능을 가지고 있어야 하는 eventHandler함수이다.

## 스크린샷
![bandicam 2024-03-02 14-17-06-916](https://github.com/coririri/haanppen-math-frontend/assets/87762581/f9b79ab4-a7ac-4357-84c8-8d05d0c9a6fa)

resolve: #33 
