### PR TITLE
config: loginLogic 수정

### DIFF
--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -2,31 +2,37 @@ import axios from 'axios';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
+const refreshInstance = axios.create({
+  baseURL: backendUrl,
+  timeout: 1000,
+});
+
 const instance = axios.create({
   baseURL: backendUrl,
   timeout: 1000,
 });
 
-// 새로운 토큰을 가져오는 함수
-const fetchNewToken = async () => {
-  const response = await instance.post('/api/login/refresh');
-  const newToken = response.data.accessToken;
-  const { role } = response.data;
-  instance.defaults.headers.common.Authorization = newToken;
-  localStorage.setItem('role', role);
-  return newToken;
-};
-
-instance.interceptors.request.use(async () => {
+instance.interceptors.request.use(async (config) => {
   // accessToken이 없거나 만료된 경우 새로운 토큰을 가져오는 로직
-  let token = instance.defaults.headers.common.Authorization;
+  const token = instance.defaults.headers.common.Authorization;
   if (!token) {
     try {
-      token = await fetchNewToken();
+      const response = await refreshInstance.post('/api/login/refresh');
+      const newToken = response.data.accessToken;
+      const { role } = response.data;
+      instance.defaults.headers.common.Authorization = newToken;
+      localStorage.setItem('role', role);
     } catch (error) {
       console.error('토큰을 갱신하는 중 에러가 발생했습니다:', error);
+      // 토큰 갱신에 실패한 경우 여기에 적절한 처리를 추가할 수 있습니다.
     }
   }
-  instance.defaults.headers.common.Authorization = token; // 요청에 토큰 설정
+  return config;
 });
+
+export const loginInstance = axios.create({
+  baseURL: backendUrl,
+  timeout: 1000,
+});
+
 export default instance;

--- a/src/apis/login.js
+++ b/src/apis/login.js
@@ -1,7 +1,7 @@
-import instance from './instance';
+import instance, { loginInstance } from './instance';
 
 const login = (userForm, setErrorMessage, navigate) => {
-  instance
+  loginInstance
     .post('/api/login', {
       userPhoneNumber: userForm.id,
       password: userForm.password,


### PR DESCRIPTION
- instance의intercept과정에서 instance로 다시 post요청을 보내서 무한 요청 에러 발생
새로운 refreshInstance만들어서 고쳤음
- intercept에서 config를 반환하지 않으면 cancelToken에러 발생함

## 개요
- Istance의 요청 Intercept 과정에서 intance를 활용해 또 post 요청을 보내, 무한 요청 오류 발생 (1)
- intercept코드에서 config를 반환 하지 않아 에러 발생 (2)
- async await코드로 에러를 catch함 (3)

## 작업 내용
- (1)에서 refreshInstance를 만들어서 고쳤음
- config를 반환하여 고침 (에러 원인 파악이 어려웠음)
- async await코드로 에러 catch

resolve: #42 
