### PR TITLE
setting: tailwind 미디어 쿼리 세팅 & 공용 페이지 미디어쿼리 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,17 +10,16 @@ function App() {
     <BrowserRouter>
       <Routes>
         {/* 공통 레이아웃 */}
-        <Route path="/" element={<CommonLayout />}>
-          {/* 단독 레이아웃 */}
-          <Route index element={<LoginPage />} />
-          <Route
-            path="nonfound-pageserver"
-            element={<NonFoundPageServerError />}
-          />
-          <Route path="server-error" element={<ServerErrorPage />} />
-        </Route>
+        <Route path="/" element={<CommonLayout />} />
         {/* 404 에러 */}
         <Route path="*" element={<NonFoundClientError />} />
+        {/* 단독 레이아웃 */}
+        <Route index element={<LoginPage />} />
+        <Route
+          path="nonfound-pageserver"
+          element={<NonFoundPageServerError />}
+        />
+        <Route path="server-error" element={<ServerErrorPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/layouts/CommonLayout.jsx
+++ b/src/components/layouts/CommonLayout.jsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 function CommonLayout() {
   return (
-    <div>
+    <div className="h-[100vh]">
       {/* 헤더 */}
       <Outlet />
     </div>

--- a/src/components/organisms/LoginForm.jsx
+++ b/src/components/organisms/LoginForm.jsx
@@ -23,18 +23,18 @@ function LoginForm({ setUserForm, errorMessage, handleLoginClick }) {
   };
 
   return (
-    <form className="w-[30.25rem] h-[16rem] flex flex-col justify-between mx-auto">
+    <form className="md:w-[30.25rem] w-[20rem] h-[16rem] flex flex-col justify-between mx-auto">
       <input
-        className="w-[30.25rem] mx-auto text-lg font-cantarell font-bold bg-white px-2 py-[0.8rem] focus:outline-none"
+        className="md:w-[30.25rem] w-[20rem] mx-auto mb-2 text-lg font-cantarell font-bold bg-white px-2 py-[0.8rem] focus:outline-none"
         type="text"
         placeholder="아이디(전화번호)"
         onChange={(e) => {
           handleChangeForm(e, 'id');
         }}
       />
-      <div className="w-[30.25rem] relative">
+      <div className="md:w-[30.25rem] w-[20rem] relative">
         <input
-          className="w-[30.25rem] mx-auto text-lg font-cantarell font-bold bg-white px-2 py-[0.8rem] focus:outline-none"
+          className="md:w-[30.25rem] w-[20rem] mx-auto text-lg font-cantarell font-bold bg-white px-2 py-[0.8rem] focus:outline-none"
           type={passwordVisibility ? 'text' : 'password'}
           placeholder="비밀번호"
           autoComplete="true"
@@ -62,18 +62,18 @@ function LoginForm({ setUserForm, errorMessage, handleLoginClick }) {
           </button>
         )}
       </div>
-      <div className="w-[30.25rem] h-[5rem] pb-6 relative flex items-center">
+      <div className="md:w-[30.25rem] w-[20rem] h-[5rem] pb-6 relative flex items-center">
         {errorMessage !== '' && (
-          <div className="w-[30.25rem] h-[2.5rem] absolute bottom-4 text-center leading-[2.5rem]">
+          <div className="md:w-[30.25rem] w-[20rem] h-[2.5rem] absolute md:bottom-4 bottom-8 text-center leading-[2.5rem]">
             <span className="font-bold text-hpRed text-lg">{errorMessage}</span>
           </div>
         )}
       </div>
       <div
-        className={`w-[30.25rem] h-[3.875rem] rounded-xl mx-auto ${errorMessage !== '' ? 'bg-hpGray ' : ' bg-hpBlue hover:bg-hpDarkBlue'}`}
+        className={`md:w-[30.25rem] w-[20rem] h-[3.875rem] rounded-xl mx-auto ${errorMessage !== '' ? 'bg-hpGray ' : ' bg-hpBlue hover:bg-hpDarkBlue'}`}
       >
         <button
-          className="w-[30.25rem] h-[3.875rem]"
+          className="md:w-[30.25rem] w-[20rem] h-[3.875rem]"
           type="button"
           onClick={handleLoginClick}
           disabled={errorMessage !== ''}

--- a/src/components/pages/LoginPage.jsx
+++ b/src/components/pages/LoginPage.jsx
@@ -25,10 +25,10 @@ function LoginPage() {
   };
 
   return (
-    <main className="w-full h-[1024px] pb-36 flex flex-col items-center justify-center bg-hpLightGray ">
+    <main className="lg:w-[1440px] md:w-[834px] w-[428px] mx-auto h-[100vh] flex flex-col items-center justify-center bg-hpLightGray ">
       <div className="mb-24">
         <img
-          className="mx-auto"
+          className="mx-auto md:w-[361px] w-[300px]"
           src={logoImages}
           alt="한편의 수학 로고 이미지"
         />

--- a/src/components/pages/NonFoundPageClientError.jsx
+++ b/src/components/pages/NonFoundPageClientError.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 function NonFoundPageClientError() {
   return (
-    <div className="w-full h-[1024px] flex flex-col justify-start items-center">
-      <div className="w-[26rem] h-[26rem] mt-24 mb-6 bg-hpGray rounded-[13rem] flex justify-center items-center">
-        <span className="text-white font-bold text-[10rem]">404</span>
+    <div className="lg:w-[1440px] md:w-[834px] w-[428px] mx-auto h-[100vh] flex flex-col justify-start items-center">
+      <div className="lg:w-[26rem] md:w-[20rem] w-[12rem] lg:h-[26rem] md:h-[20rem] h-[12rem] lg:rounded-[16rem] md:rounded-[13rem] rounded-[6rem] mt-24 mb-6 bg-hpGray flex justify-center items-center">
+        <span className="text-white font-bold lg:text-[10rem] md:text-[8rem] text-[6rem]">
+          404
+        </span>
       </div>
-      <span className="text-hpLightkBlack text-[3rem] text-center font-bold">
+      <span className="text-hpLightkBlack lg:text-[3rem] md:text-[2rem] text-[1.5rem] text-center font-bold">
         찾고 게신 페이지를 발견할 수 없습니다.
       </span>
     </div>

--- a/src/components/pages/NonFoundPageServerError.jsx
+++ b/src/components/pages/NonFoundPageServerError.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 function NonFoundPageServerError() {
   return (
-    <div className="w-full h-[1024px] flex flex-col justify-start items-center">
-      <div className="w-[26rem] h-[26rem] mt-24 mb-6 bg-hpGray rounded-[13rem] flex justify-center items-center">
-        <span className="text-white font-bold text-[10rem]">404</span>
+    <div className="lg:w-[1440px] md:w-[834px] w-[428px] mx-auto h-[100vh] flex flex-col justify-start items-center">
+      <div className="lg:w-[26rem] md:w-[20rem] w-[12rem] lg:h-[26rem] md:h-[20rem] h-[12rem] lg:rounded-[16rem] md:rounded-[13rem] rounded-[6rem] mt-24 mb-6 bg-hpGray flex justify-center items-center">
+        <span className="text-white font-bold lg:text-[10rem] md:text-[8rem] text-[6rem]">
+          404
+        </span>
       </div>
-      <span className="text-hpLightkBlack text-[3rem] text-center font-bold">
+      <span className="text-hpLightkBlack lg:text-[3rem] md:text-[2rem] text-[1.5rem] text-center font-bold">
         해당 리소스가 서버에 존재하지 않습니다.
       </span>
     </div>

--- a/src/components/pages/ServerErrorPage.jsx
+++ b/src/components/pages/ServerErrorPage.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 function ServerErrorPage() {
   return (
-    <div className="w-full h-[1024px] flex flex-col justify-start items-center">
-      <div className="w-[26rem] h-[26rem] mt-24 mb-6 bg-hpGray rounded-[13rem] flex justify-center items-center">
-        <span className="text-white font-bold text-[10rem]">500</span>
+    <div className="lg:w-[1440px] md:w-[834px] w-[428px] mx-auto h-[100vh] flex flex-col justify-start items-center">
+      <div className="lg:w-[26rem] md:w-[20rem] w-[12rem] lg:h-[26rem] md:h-[20rem] h-[12rem] lg:rounded-[16rem] md:rounded-[13rem] rounded-[6rem] mt-24 mb-6 bg-hpGray flex justify-center items-center">
+        <span className="text-white font-bold lg:text-[10rem] md:text-[8rem] text-[6rem]">
+          500
+        </span>
       </div>
-      <span className="text-hpLightkBlack text-[3rem] font-bold">
+      <span className="text-hpLightkBlack lg:text-[3rem] md:text-[2rem] text-[1.5rem] text-center font-bold">
         Internal Server Error
       </span>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -50,8 +50,7 @@
 
 body {
   max-width: 1440px;
-  height: 1024px;
-  max-height: 1024px;
+  height: 100vh;
   margin: 0 auto;
   font-family:
     Sejong-hospital-Light,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,10 @@ module.exports = {
         sjLight: ['Sejong-hospital-Light', 'sans', 'serif'],
         cantarell: ['Cantarell'],
       },
+      screens: {
+        md: '834px',
+        lg: '1440px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 개요
- 내용을 입력해주세요.

## 작업 내용
- tailwind 미디어 쿼리 적용
      md: '834px',
       lg: '1440px',
sm(모바일)을 base로 css를 주고 태블릿, 데스크탑이 필요한 부분에 미디어 쿼리를 적용해 사용
1440px < 데스크탑
834px < 태블릿

- loginPage, 각종 에러 페이지 미디어 쿼리 적용

resolve: #45 
