### PR TITLE
refreshToken이 필요한 부분을 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
         {/* 404 에러 */}
         <Route path="*" element={<NonFoundClientError />} />
         {/* 단독 레이아웃 */}
-        <Route index element={<LoginPage />} />
+        <Route path="login" element={<LoginPage />} />
         <Route
           path="nonfound-pageserver"
           element={<NonFoundPageServerError />}

--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -28,6 +28,10 @@ instance.interceptors.request.use(async (config) => {
     } catch (error) {
       console.error('토큰을 갱신하는 중 에러가 발생했습니다:', error);
       // 토큰 갱신에 실패한 경우 여기에 적절한 처리를 추가할 수 있습니다.
+      setTimeout(() => {
+        alert('로그인 페이지로 이동합니다');
+        window.location.href = '/login';
+      }, 3000);
     }
   }
   return config;

--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
-const refreshInstance = axios.create({
+export const refreshInstance = axios.create({
   baseURL: backendUrl,
   timeout: 1000,
 });
@@ -14,8 +14,10 @@ const instance = axios.create({
 
 instance.interceptors.request.use(async (config) => {
   // accessToken이 없거나 만료된 경우 새로운 토큰을 가져오는 로직
-  const token = instance.defaults.headers.common.Authorization;
-  if (!token) {
+  const curToken = instance.defaults.headers.common.Authorization;
+  const curUserName = localStorage.getItem('userName');
+  const curRole = localStorage.getItem('role');
+  if (!curToken || !curUserName || !curRole) {
     try {
       const response = await refreshInstance.post('/api/login/refresh');
       const newToken = response.data.accessToken;

--- a/src/components/layouts/CommonLayout.jsx
+++ b/src/components/layouts/CommonLayout.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 import instance, { refreshInstance } from '../../apis/instance';
 
 function CommonLayout() {
+  const navigate = useNavigate();
   useEffect(() => {
     const fetchData = async () => {
       const curToken = instance.defaults.headers.common.Authorization;
@@ -19,6 +20,10 @@ function CommonLayout() {
         } catch (error) {
           console.error('토큰을 갱신하는 중 에러가 발생했습니다:', error);
           // 토큰 갱신에 실패한 경우 여기에 적절한 처리를 추가할 수 있습니다.
+          setTimeout(() => {
+            alert('로그인 페이지로 이동합니다');
+            navigate('/login');
+          }, 3000);
         }
       }
     };

--- a/src/components/layouts/CommonLayout.jsx
+++ b/src/components/layouts/CommonLayout.jsx
@@ -1,7 +1,31 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+import instance, { refreshInstance } from '../../apis/instance';
 
 function CommonLayout() {
+  useEffect(() => {
+    const fetchData = async () => {
+      const curToken = instance.defaults.headers.common.Authorization;
+      const curUserName = localStorage.getItem('userName');
+      const curRole = localStorage.getItem('role');
+      if (!curToken || !curUserName || !curRole) {
+        try {
+          const response = await refreshInstance.post('/api/login/refresh');
+          const newToken = response.data.accessToken;
+          const { role, userName } = response.data;
+          instance.defaults.headers.common.Authorization = newToken;
+          localStorage.setItem('role', role);
+          localStorage.setItem('userName', userName);
+        } catch (error) {
+          console.error('토큰을 갱신하는 중 에러가 발생했습니다:', error);
+          // 토큰 갱신에 실패한 경우 여기에 적절한 처리를 추가할 수 있습니다.
+        }
+      }
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <div className="h-[100vh]">
       {/* 헤더 */}


### PR DESCRIPTION
## 개요
refreshToken을 통해 사용자 정보를 재 발급 받아야 하는 부분 로직 구현

## 작업 내용
- 페이지 새로 고침 or 접속 시 LocalStorage에 role 또는 userName이 없거나, accessToken이 없을 때 refreshToken을 통해 재 발급 받기
- 모든 api 요청 시 동일하게 재 발급 받기
- refreshToken이 없을 때, 컴포넌트 내부에서는 navigate를 이용해 외부에서는 window.location.href을 이용해 로그인 페이지로 리 다이렉션

resolve: #46 
